### PR TITLE
Replace boost::string_ref with boost::string_view

### DIFF
--- a/include/trial/protocol/bintoken/detail/decoder.hpp
+++ b/include/trial/protocol/bintoken/detail/decoder.hpp
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 #include <boost/config.hpp>
-#include <boost/utility/string_ref.hpp>
+#include <trial/protocol/detail/string_view.hpp>
 #include <trial/protocol/bintoken/token.hpp>
 #include <trial/protocol/bintoken/error.hpp>
 
@@ -30,7 +30,7 @@ class decoder
 {
 public:
     using value_type = std::uint8_t;
-    using view_type = boost::basic_string_ref<value_type>;
+    using view_type = trial::protocol::detail::basic_string_view<value_type>;
 
     template <typename T>
     decoder(const T& input);

--- a/include/trial/protocol/bintoken/detail/encoder.hpp
+++ b/include/trial/protocol/bintoken/detail/encoder.hpp
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <string>
 #include <memory>
-#include <boost/utility/string_ref.hpp>
+#include <trial/protocol/detail/string_view.hpp>
 #include <trial/protocol/bintoken/token.hpp>
 
 namespace trial
@@ -32,8 +32,8 @@ class encoder
 public:
     using value_type = std::uint8_t;
     using size_type = std::size_t;
-    using view_type = boost::basic_string_ref<value_type>;
-    using string_view_type = boost::basic_string_ref<char>;
+    using view_type = trial::protocol::detail::basic_string_view<value_type>;
+    using string_view_type = trial::protocol::detail::basic_string_view<char>;
 
     template <typename T>
     encoder(T&);

--- a/include/trial/protocol/buffer/base.hpp
+++ b/include/trial/protocol/buffer/base.hpp
@@ -12,7 +12,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <cstddef> // std::size_t
-#include <boost/utility/string_ref.hpp>
+#include <trial/protocol/detail/string_view.hpp>
 
 namespace trial
 {
@@ -27,7 +27,7 @@ class base
 public:
     using value_type = CharT;
     using size_type = std::size_t;
-    using view_type = boost::basic_string_ref<value_type>;
+    using view_type = trial::protocol::detail::basic_string_view<value_type>;
 
     virtual ~base() {}
 

--- a/include/trial/protocol/detail/string_view.hpp
+++ b/include/trial/protocol/detail/string_view.hpp
@@ -1,0 +1,41 @@
+#ifndef TRIAL_PROTOCOL_DETAIL_STRING_VIEW_HPP
+#define TRIAL_PROTOCOL_DETAIL_STRING_VIEW_HPP
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright © 2017 Vinícius dos Santos Oliveira <vini.ipsmaker@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <boost/version.hpp>
+
+#if BOOST_VERSION < 106100
+#include <boost/utility/string_ref.hpp>
+#else
+#include <trial/protocol/detail/string_view.hpp>
+#endif
+
+namespace trial {
+namespace protocol {
+namespace detail {
+
+#if BOOST_VERSION < 106100
+template<class T>
+using basic_string_view = boost::basic_string_ref<T>;
+#else
+template<class T>
+using basic_string_view = boost::basic_string_view<T>;
+#endif
+
+typedef basic_string_view<char> string_view;
+
+} // namespace detail {
+} // namespace protocol {
+} // namespace trial {
+
+
+#endif // TRIAL_PROTOCOL_DETAIL_STRING_VIEW_HPP

--- a/include/trial/protocol/json/detail/decoder.hpp
+++ b/include/trial/protocol/json/detail/decoder.hpp
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <string>
 #include <boost/config.hpp>
-#include <boost/utility/string_ref.hpp>
+#include <trial/protocol/detail/string_view.hpp>
 #include <trial/protocol/json/token.hpp>
 #include <trial/protocol/json/error.hpp>
 
@@ -34,7 +34,7 @@ class basic_decoder
 public:
     using size_type = std::size_t;
     using value_type = CharT;
-    using view_type = boost::basic_string_ref<CharT>;
+    using view_type = trial::protocol::detail::basic_string_view<CharT>;
 
     basic_decoder(const view_type& input);
 

--- a/include/trial/protocol/json/detail/encoder.hpp
+++ b/include/trial/protocol/json/detail/encoder.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <memory>
 #include <boost/none.hpp>
-#include <boost/utility/string_ref.hpp>
+#include <trial/protocol/detail/string_view.hpp>
 #include <trial/protocol/buffer/base.hpp>
 
 namespace trial
@@ -34,7 +34,7 @@ public:
     using value_type = CharT;
     using size_type = std::size_t;
     using buffer_type = buffer::base<value_type>;
-    using view_type = boost::basic_string_ref<value_type>;
+    using view_type = trial::protocol::detail::basic_string_view<value_type>;
 
     template <typename T>
     basic_encoder(T&);

--- a/include/trial/protocol/json/reader.hpp
+++ b/include/trial/protocol/json/reader.hpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <stack>
 #include <boost/config.hpp>
-#include <boost/utility/string_ref.hpp>
+#include <trial/protocol/detail/string_view.hpp>
 #include <trial/protocol/json/error.hpp>
 #include <trial/protocol/json/token.hpp>
 #include <trial/protocol/json/detail/decoder.hpp>

--- a/test/bintoken/writer_suite.cpp
+++ b/test/bintoken/writer_suite.cpp
@@ -321,7 +321,7 @@ void test_view()
     std::vector<value_type> result;
     format::writer writer(result);
     std::string data("ABC");
-    boost::string_ref view(data.data());
+    trial::protocol::detail::string_view view(data.data());
     TRIAL_PROTOCOL_TEST_EQUAL(writer.value(view), 5);
     TRIAL_PROTOCOL_TEST_EQUAL(result.size(), 5);
     TRIAL_PROTOCOL_TEST_EQUAL(result[0], token::code::string8);


### PR DESCRIPTION
`boost::string_ref` is deprecated and doesn't play nice with
`boost::string_view`:

```
error: no matching function for call to ‘trial::protocol::json::basic_reader<char>::basic_reader(boost::string_view)’
     json::reader reader(boost::string_view(raw_json_data, raw_json_data_size));
note:   no known conversion for argument 1 from ‘boost::string_view {aka boost::basic_string_view<char, std::char_traits<char> >}’ to ‘const view_type& {aka const boost::basic_string_ref<char, std::char_traits<char> >&}’
```