### PR TITLE
Add key::erase algorithm

### DIFF
--- a/include/trial/dynamic/algorithm.hpp
+++ b/include/trial/dynamic/algorithm.hpp
@@ -12,6 +12,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <trial/dynamic/algorithm/count.hpp>
+#include <trial/dynamic/algorithm/erase.hpp>
 #include <trial/dynamic/algorithm/find.hpp>
 
 #endif // TRIAL_DYNAMIC_ALGORITHM_HPP

--- a/include/trial/dynamic/algorithm/erase.hpp
+++ b/include/trial/dynamic/algorithm/erase.hpp
@@ -1,0 +1,49 @@
+#ifndef TRIAL_DYNAMIC_ALGORITHM_ERASE_HPP
+#define TRIAL_DYNAMIC_ALGORITHM_ERASE_HPP
+
+#include <trial/dynamic/algorithm/find.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (C) 2018 Bjorn Reese <breese@users.sourceforge.net>
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <trial/dynamic/variable.hpp>
+
+namespace trial
+{
+namespace dynamic
+{
+namespace key
+{
+
+template <template <typename> class Allocator, typename T>
+auto erase(basic_variable<Allocator>& self,
+           const T& other) -> typename basic_variable<Allocator>::key_iterator
+{
+    switch (self.symbol())
+    {
+    case symbol::map:
+        {
+            auto where = key::find(self, other);
+            auto result = where;
+            ++result;
+            self.erase(where.base());
+            return result;
+        }
+
+    default:
+        return self.key_end();
+    }
+}
+
+} // namespace key
+} // namespace dynamic
+} // namespace trial
+
+#endif // TRIAL_DYNAMIC_ALGORITHM_ERASE_HPP

--- a/test/dynamic/CMakeLists.txt
+++ b/test/dynamic/CMakeLists.txt
@@ -56,6 +56,7 @@ trial_add_test(dynamic_std_swap_ranges_suite std/swap_ranges_suite.cpp)
 trial_add_test(dynamic_std_transform_suite std/transform_suite.cpp)
 trial_add_test(dynamic_std_unique_suite std/unique_suite.cpp)
 trial_add_test(dynamic_std_upper_bound_suite std/upper_bound_suite.cpp)
+trial_add_test(dynamic_erase_suite erase_suite.cpp)
 
 # <numeric>
 trial_add_test(dynamic_std_accumulate_suite std/accumulate_suite.cpp)

--- a/test/dynamic/erase_suite.cpp
+++ b/test/dynamic/erase_suite.cpp
@@ -1,0 +1,89 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (C) 2018 Vinícius dos Santos Oliveira <vini.ipsmaker@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <trial/protocol/core/detail/lightweight_test.hpp>
+#include <trial/dynamic/variable.hpp>
+#include <trial/dynamic/algorithm/erase.hpp>
+
+using namespace trial::dynamic;
+
+//-----------------------------------------------------------------------------
+// key::erase
+//-----------------------------------------------------------------------------
+
+void key_erase_null()
+{
+    variable data, data2;
+    // Cannot iterate over null, so nothing changes
+    auto it = data.key_begin();
+    TRIAL_PROTOCOL_TEST(key::erase(data, 0) == it);
+    TRIAL_PROTOCOL_TEST(data == data2);
+}
+
+void key_erase_string_matching_key()
+{
+    variable data("test");
+    TRIAL_PROTOCOL_TEST(data == "test");
+    auto it = key::erase(data, "test");
+    TRIAL_PROTOCOL_TEST(it == data.key_end());
+    TRIAL_PROTOCOL_TEST(data == "test");
+}
+
+void key_erase_first_out_of_three_on_list()
+{
+    variable data{"test", 2, 3};
+    auto it = key::erase(data, "test");
+    TRIAL_PROTOCOL_TEST(it == data.key_end());
+    TRIAL_PROTOCOL_TEST(*data.begin() == "test");
+}
+
+void key_erase_first_out_of_three()
+{
+    variable data;
+    data["a"] = 1;
+    data["b"] = 2;
+    data["c"] = 3;
+    auto it = key::erase(data, std::string("a"));
+    TRIAL_PROTOCOL_TEST(it == data.key_begin());
+    TRIAL_PROTOCOL_TEST(*it == "b");
+    TRIAL_PROTOCOL_TEST(data.size() == 2);
+}
+
+void key_erase_last()
+{
+    variable data;
+    data["a"] = 1;
+    data["b"] = 2;
+    data["c"] = 3;
+    auto it = key::erase(data, std::string("c"));
+    TRIAL_PROTOCOL_TEST(it == data.key_end());
+    TRIAL_PROTOCOL_TEST(data.size() == 2);
+    TRIAL_PROTOCOL_TEST(data["a"] == 1);
+    TRIAL_PROTOCOL_TEST(data["b"] == 2);
+}
+
+void key_erase_on_one_sized_map()
+{
+    variable data;
+    data["a"] = 1;
+    auto it = key::erase(data, std::string("a"));
+    TRIAL_PROTOCOL_TEST(it == data.key_end());
+    TRIAL_PROTOCOL_TEST(data.size() == 0);
+}
+
+int main()
+{
+    key_erase_null();
+    key_erase_string_matching_key();
+    key_erase_first_out_of_three_on_list();
+    key_erase_first_out_of_three();
+    key_erase_last();
+    key_erase_on_one_sized_map();
+}


### PR DESCRIPTION
Could you give me a hint on how to create a `dynamic::key_iterator` from a `map::iterator`? I understood the `current` union containing the iterator, but I could make use of a suggestion on where to add such conversion (add a new constructor to `key_iterator`, make the new algorithm a friend function...).