### PR TITLE
Add missing end_array failing test

### DIFF
--- a/test/json/reader_suite.cpp
+++ b/test/json/reader_suite.cpp
@@ -555,6 +555,17 @@ void fail_missing_begin_after_comma()
     TRIAL_PROTOCOL_TEST_EQUAL(reader.tail(), "]");
 }
 
+void fail_missing_end()
+{
+    const char input[] = "[";
+    json::reader reader(input);
+    TRIAL_PROTOCOL_TEST_EQUAL(reader.code(), token::code::begin_array);
+    TRIAL_PROTOCOL_TEST_EQUAL(reader.level(), 1);
+    TRIAL_PROTOCOL_TEST_EQUAL(reader.next(), false);
+    TRIAL_PROTOCOL_TEST_EQUAL(reader.code(), token::code::error_expected_end_array);
+    TRIAL_PROTOCOL_TEST_EQUAL(reader.level(), 1);
+}
+
 void fail_concatenated_arrays()
 {
     const char input[] = "[][]";
@@ -605,6 +616,7 @@ void run()
     fail_missing_begin();
     fail_missing_begin_after_array();
     fail_missing_begin_after_comma();
+    fail_missing_end();
     fail_concatenated_arrays();
     fail_nested_concatenated_arrays();
 }


### PR DESCRIPTION
I was caught by surprise here. I thought I could mirror the loop at

https://github.com/breese/trial.protocol/blob/cbb39086fde32804e71e7d075267f4cbef946907/example/json/push_parser/push_parser.hpp#L29-L76

and only check for `json::token::symbol::error` afterwards to know if the JSON was valid. By now I see I also need to test for `reader.level() == 0`.

Maybe this behaviour deserves some discussion? Not really sure what's the proper take here as I just stumbled upon it.