### PR TITLE
**WIP DO NOT MERGE IT**: Add automatic serialization support for boost::hana::Struct

### DIFF
--- a/include/trial/protocol/json/serialization/boost/hana.hpp
+++ b/include/trial/protocol/json/serialization/boost/hana.hpp
@@ -1,0 +1,84 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (C) 2021 Vinícius dos Santos Oliveira
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef TRIAL_PROTOCOL_JSON_SERIALIZATION_BOOST_HANA_HPP
+#define TRIAL_PROTOCOL_JSON_SERIALIZATION_BOOST_HANA_HPP
+
+#include <trial/protocol/json/serialization/serialization.hpp>
+#include <boost/hana.hpp>
+#include <trial/protocol/json/token.hpp>
+#include <trial/protocol/json/partial/skip.hpp>
+
+namespace trial
+{
+namespace protocol
+{
+namespace serialization
+{
+
+template <typename CharT, typename Value>
+struct save_overloader<json::basic_oarchive<CharT>,
+                       Value,
+                       std::enable_if_t<boost::hana::Struct<Value>::value>>
+{
+    static void save(json::basic_oarchive<CharT>& ar,
+                     const Value& data,
+                     const unsigned int /*protocol_version*/)
+    {
+        using string_view = core::detail::basic_string_view<CharT>;
+
+        ar.template save<json::token::begin_object>();
+        boost::hana::for_each(data, [&ar](auto member) {
+            auto key = boost::hana::first(member);
+            ar.save(string_view(key.c_str(), boost::hana::size(key)));
+            // TODO: what if subvalue uses old reflection infra? then it
+            // requires us to write the necessary framing (begin_array and
+            // end_array)
+            ar << boost::hana::second(member);
+        });
+        ar.template save<json::token::end_object>();
+    }
+};
+
+template <typename CharT, typename Value>
+struct load_overloader<json::basic_iarchive<CharT>,
+                       Value,
+                       std::enable_if_t<boost::hana::Struct<Value>::value>>
+{
+    static void load(json::basic_iarchive<CharT>& ar,
+                     Value& data,
+                     const unsigned int /*protocol_version*/)
+    {
+        ar.template load<json::token::begin_object>();
+        for (;;) {
+            if (ar.symbol() == json::token::symbol::end_object) {
+                ar.template load<json::token::end_object>();
+                break;
+            }
+
+            // skip key
+            //json::partial::skip(ar.reader());
+            json::partial::skip(const_cast<json::reader&>(ar.reader()));
+            // skip value
+            //json::partial::skip(ar.reader());
+            json::partial::skip(const_cast<json::reader&>(ar.reader()));
+
+            // TODO: actually decode stuff
+            //ar >> x;
+        }
+        ar.template load<json::token::end_object>();
+    }
+};
+
+} // namespace serialization
+} // namespace protocol
+} // namespace trial
+
+#endif // TRIAL_PROTOCOL_JSON_SERIALIZATION_BOOST_HANA_HPP

--- a/include/trial/protocol/json/serialization/boost/hana.hpp
+++ b/include/trial/protocol/json/serialization/boost/hana.hpp
@@ -64,11 +64,17 @@ struct load_overloader<json::basic_iarchive<CharT>,
             }
 
             // skip key
-            //json::partial::skip(ar.reader());
-            json::partial::skip(const_cast<json::reader&>(ar.reader()));
+            {
+                auto r = ar.reader();
+                json::partial::skip(r);
+                ar.reader(std::move(r));
+            }
             // skip value
-            //json::partial::skip(ar.reader());
-            json::partial::skip(const_cast<json::reader&>(ar.reader()));
+            {
+                auto r = ar.reader();
+                json::partial::skip(r);
+                ar.reader(std::move(r));
+            }
 
             // TODO: actually decode stuff
             //ar >> x;

--- a/test/json/CMakeLists.txt
+++ b/test/json/CMakeLists.txt
@@ -19,6 +19,7 @@ trial_add_test(json_writer_suite writer_suite.cpp)
 trial_add_test(json_iarchive_suite iarchive_suite.cpp)
 trial_add_test(json_oarchive_suite oarchive_suite.cpp)
 trial_add_test(json_partial_skip_suite skip_suite.cpp)
+trial_add_test(hana_reflection_suite hana_reflection_suite.cpp)
 
 # Tree processing
 trial_add_test(json_parse_suite parse_suite.cpp)

--- a/test/json/hana_reflection_suite.cpp
+++ b/test/json/hana_reflection_suite.cpp
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (C) 2021 Vinícius dos Santos Oliveira
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <sstream>
+#include <trial/protocol/buffer/ostream.hpp>
+#include <trial/protocol/json/serialization/boost/hana.hpp>
+#include <trial/protocol/core/detail/lightweight_test.hpp>
+
+using namespace trial::protocol;
+
+//-----------------------------------------------------------------------------
+// Basic types
+//-----------------------------------------------------------------------------
+
+struct Foobar {
+    BOOST_HANA_DEFINE_STRUCT(Foobar,
+        (int, foo),
+        (int, bar),
+        (int, baz)
+    );
+};
+
+namespace basic_suite
+{
+
+void test_oarchive()
+{
+    std::ostringstream result;
+    json::oarchive ar(result);
+    Foobar value{5, 10, 0};
+    ar << value;
+    TRIAL_PROTOCOL_TEST_EQUAL(result.str(), "{\"foo\":5,\"bar\":10,\"baz\":0}");
+}
+
+void test_iarchive()
+{
+    const char input[] = "{\"foo\":5,\"bar\":10,\"baz\":0}";
+    json::iarchive in(input);
+    Foobar value{1, 2, 3};
+    TRIAL_PROTOCOL_TEST_NO_THROW(in >> value);
+    TRIAL_PROTOCOL_TEST_EQUAL(value.foo, 5);
+    TRIAL_PROTOCOL_TEST_EQUAL(value.bar, 10);
+    TRIAL_PROTOCOL_TEST_EQUAL(value.baz, 0);
+}
+
+void run()
+{
+    test_oarchive();
+    test_iarchive();
+}
+
+} // namespace basic_suite
+
+//-----------------------------------------------------------------------------
+// main
+//-----------------------------------------------------------------------------
+
+int main()
+{
+    basic_suite::run();
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
So... as I was saying in a previous email exchange of ours, I'll need `iarchive::reader()` to return a non-const reference so I can use algorithms such as `partial::skip()` to skip over unwanted extraneous members for instance.

Users that specialize the types to have specific serialization for JSON might want just the same as well.

The code is fairly small and you could already take a look.