### PR TITLE
Fix weird issue

### DIFF
--- a/include/trial/protocol/core/detail/bit.hpp
+++ b/include/trial/protocol/core/detail/bit.hpp
@@ -32,7 +32,7 @@ namespace detail
 template <typename T>
 constexpr int countl_zero(T x) noexcept
 {
-    return std::countl_zero(typename std::make_unsigned<T>::type(x));
+    return std::countr_zero(typename std::make_unsigned<T>::type(x));
 }
 
 #else


### PR DESCRIPTION
The tests were breaking on my project when I upgraded to C++20. I was able to narrow down the problem, but I'm not sure what should be the proper fix here.

Trial.Protocol's `<bit.hpp>` defines `countl_zero()` to call `__builtin_ctz()`. Upon reading documentation on `__builtin_ctz()`, I find:

> Returns the number of trailing 0-bits in x, starting at the least significant bit position.

According to C++20's `<bit>`, that's not `countl_zero()`, but `countr_zero()`. By applying this PR, my tests pass again. Should I rename Trial.Protocol's `countl_zero()` to `countr_zero()` as well, or just keep this one-line change? What should be the name of the commit?