### PR TITLE
add separator() to insert the correct separator when using literal()

### DIFF
--- a/include/trial/protocol/json/detail/writer.ipp
+++ b/include/trial/protocol/json/detail/writer.ipp
@@ -150,6 +150,13 @@ auto basic_writer<CharT, N>::literal(const view_type& data) BOOST_NOEXCEPT -> si
 }
 
 template <typename CharT, std::size_t N>
+void basic_writer<CharT, N>::separator()
+{
+    validate_scope();
+    stack.top().write_separator();
+}
+
+template <typename CharT, std::size_t N>
 void basic_writer<CharT, N>::validate_scope()
 {
     if (stack.empty())

--- a/include/trial/protocol/json/writer.hpp
+++ b/include/trial/protocol/json/writer.hpp
@@ -57,6 +57,9 @@ public:
     //! @brief Write raw output.
     size_type literal(const view_type&) BOOST_NOEXCEPT;
 
+    //! @brief Write separator when called before literal()
+    void separator();
+
 #ifndef BOOST_DOXYGEN_INVOKED
 private:
     void validate_scope();


### PR DESCRIPTION
fixes #49 